### PR TITLE
chore: update url warning to liquidity.dfi.dev

### DIFF
--- a/src/components/Header/URLWarning.tsx
+++ b/src/components/Header/URLWarning.tsx
@@ -30,15 +30,15 @@ export default function URLWarning() {
     <PhishAlert isActive={showURLWarning}>
       <div style={{ display: 'flex' }}>
         <AlertTriangle style={{ marginRight: 6 }} size={12} /> Make sure the URL is
-        <code style={{ padding: '0 4px', display: 'inline', fontWeight: 'bold' }}>app.uniswap.org</code>
+        <code style={{ padding: '0 4px', display: 'inline', fontWeight: 'bold' }}>liquidity.dfi.dev</code>
       </div>
       <StyledClose size={12} onClick={toggleURLWarning} />
     </PhishAlert>
-  ) : window.location.hostname === 'app.uniswap.org' ? (
+  ) : window.location.hostname === 'liquidity.dfi.dev' ? (
     <PhishAlert isActive={showURLWarning}>
       <div style={{ display: 'flex' }}>
         <AlertTriangle style={{ marginRight: 6 }} size={12} /> Always make sure the URL is
-        <code style={{ padding: '0 4px', display: 'inline', fontWeight: 'bold' }}>app.uniswap.org</code> - bookmark it
+        <code style={{ padding: '0 4px', display: 'inline', fontWeight: 'bold' }}>liquidity.dfi.dev</code> - bookmark it
         to be safe.
       </div>
       <StyledClose size={12} onClick={toggleURLWarning} />


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Under certain conditions on mobile, the URL warning shows up with the copy `Make sure the URL is app.uniswap.org`. Updating this to to `dfi.liquidity.dev`.

![image](https://user-images.githubusercontent.com/506667/180844275-42674da1-9ae5-4c50-a7f4-b549457640ad.png)

#### Additional comments?:
