### PR TITLE
chore: update supportedChainIds to mainnet, goerli

### DIFF
--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -29,7 +29,7 @@ export function getNetworkLibrary(): Web3Provider {
 }
 
 export const injected = new InjectedConnector({
-  supportedChainIds: [1, 3, 4, 5, 42]
+  supportedChainIds: [1, 5]
 })
 
 // mainnet only


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

We're only supporting users on `mainnet` and `goerli` i.e. chain IDs `1` and `5`. For all other networks, we should show `Wrong Network` so users will know they need to switch their networks.

On `mainnet` and `goerli`, we show:

<img width="505" alt="image" src="https://user-images.githubusercontent.com/506667/180917995-b7dd1883-a27f-4585-a168-9dec84b12331.png">

On all other networks, we show:

<img width="505" alt="image" src="https://user-images.githubusercontent.com/506667/180918034-5ae6bc2d-73b4-4d89-8e8e-62f3e4451781.png">

#### Additional comments?:
