### PR TITLE
fix(ui-ux): poolpair selection overflow

### DIFF
--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -50,6 +50,7 @@ import UnsupportedCurrencyFooter from 'components/swap/UnsupportedCurrencyFooter
 
 const LpFrame = styled.div`
   display: flex;
+  overflow: auto;
   grid-template-columns: 20% 20% 20% 20%;
   align-items: center;
   justify-content: space-between;
@@ -71,6 +72,12 @@ const LpFrame = styled.div`
   ${({ theme }) => theme.mediaWidth.upToExtraSmall`
         padding: 0.5rem 1rem;
   `}
+
+  -ms-overflow-style: none;
+
+  &::-webkit-scrollbar {
+    display: none; /* for Chrome, Safari, and Opera */
+  }
 `
 const activeClassName = 'ACTIVE'
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

The `StyledNavLink` poolpair choices were overflowing, causing other components to overflow too.

Added `overflow: auto` and disabled the scrollbar that comes along with it.
* On desktop, might look like it's not centered though
* On mobile, users can scroll to select the respective poolpairs

<img width="522" alt="image" src="https://user-images.githubusercontent.com/506667/180921272-7f634f46-30ac-420e-b3a7-66a293349f9a.png">

<img width="522" alt="image" src="https://user-images.githubusercontent.com/506667/180921305-af587db2-4eaf-434e-a17b-3273d2fb4987.png">


#### Additional comments?:
