### PR TITLE
chore: cleaned up default token list

### DIFF
--- a/src/constants/default-token-list.json
+++ b/src/constants/default-token-list.json
@@ -59,7 +59,7 @@
       "symbol": "WETH",
       "decimals": 18,
       "chainId": 5,
-      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6/logo.png"
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
     },
     {
       "name": "DeFiChain Token",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Cleaned up the default token list to only show:

* USDC
* USDT
* WETH
* DFI

On `mainnet` and `goerli`. ETH is built into Uniswap interface without the use of a token list, hence won't be inside.

#### Additional comments?:
