### PR TITLE
chore: poolpair overflow styling

### DIFF
--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -54,6 +54,7 @@ import UnsupportedCurrencyFooter from 'components/swap/UnsupportedCurrencyFooter
 
 const LpFrame = styled.div`
   display: flex;
+  overflow: auto;
   grid-template-columns: 20% 20% 20% 20%;
   align-items: center;
   justify-content: space-between;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Fixed linting.

Also fixed the overflow issue, it got overwritten. Let's stick to `overflow: auto` for now while we think of a better design in the future.

See buttons getting cut off:

<img width="467" alt="image" src="https://user-images.githubusercontent.com/506667/180985709-84bad774-dc29-419c-9fcf-90d8ab04a0bf.png">


#### Additional comments?:
