### PR TITLE
chore: poolpair selection styling

### DIFF
--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -64,7 +64,8 @@ const LpFrame = styled.div`
   top: 0;
   position: relative;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-  padding: 1rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
   z-index: 2;
   ${({ theme }) => theme.mediaWidth.upToMedium`
     grid-template-columns: 1fr;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

On desktop, we've got left and right padding of `1rem` causing the row to not look centered.

<img width="356" alt="image" src="https://user-images.githubusercontent.com/506667/181153106-498dc3ec-cad3-4a4b-966b-dac22cf5e96a.png">

The fix is to not have padding for left and right, so that it'll look like this on desktop:

<img width="356" alt="image" src="https://user-images.githubusercontent.com/506667/181153071-f9fc99a1-d1ab-43f8-a9c0-86c01a1d6f81.png">

We can relook at the styling again.

#### Additional comments?:
