### PR TITLE
fix: show uniswap pool as a distinct row

### DIFF
--- a/src/components/PositionCard/index.tsx
+++ b/src/components/PositionCard/index.tsx
@@ -162,8 +162,8 @@ export function MinimalPositionCard({ pair, showUnwrapped = false, border }: Pos
 export default function FullPositionCard({ pair, border, stakedBalance }: PositionCardProps) {
   const { account } = useActiveWeb3React()
 
-  const currency1 = unwrappedToken(pair.token0)
-  const currency0 = unwrappedToken(pair.token1)
+  const currency0 = unwrappedToken(pair.token0)
+  const currency1 = unwrappedToken(pair.token1)
 
   const [showMore, setShowMore] = useState(false)
 
@@ -274,7 +274,7 @@ export default function FullPositionCard({ pair, border, stakedBalance }: Positi
               {token1DepositedRewards ? (
                 <RowFixed>
                   <Text fontSize={16} fontWeight={500} marginLeft={'6px'}>
-                    {token0DepositedRewards?.toSignificant(6)}
+                    {token1DepositedRewards?.toSignificant(6)}
                   </Text>
                   <CurrencyLogo size="20px" style={{ marginLeft: '8px' }} currency={currency1} />
                 </RowFixed>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Currently in `Your liquidity`, the `Your total pool tokens` reflect the exact same values as `Pool tokens in rewards pool` even though a user may have existing liquidity in the Uniswap pool that differ from the Rewards pool.

<img width="693" alt="image" src="https://user-images.githubusercontent.com/506667/182038522-191e59ff-1852-4b00-9316-dcd4e3e30be1.png">

Updated the `Your liquidity` section (the `FullPositionCard`) to better acknowledge a user's existing liquidity in Uniswap -- and that it not accrue the additional DFI rewards.

<img width="693" alt="image" src="https://user-images.githubusercontent.com/506667/182038560-f65692a6-b3b0-4fb2-b5fa-6c2e58a58a1c.png">

In other words, the above pic's `Pool tokens in Uniswap pool` should match values shown on https://app.uniswap.org/#/pool/v2?chain=goerli

<img width="693" alt="image" src="https://user-images.githubusercontent.com/506667/182038629-4ea36c70-ee76-4692-a2c4-1a778c8c5e6d.png">

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
