### PR TITLE
chore: add release drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,27 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: 'Features'
+    labels:
+      - 'kind/feature'
+  - title: 'Fixes'
+    labels:
+      - 'kind/fix'
+  - title: 'Chore & Maintenance'
+    labels:
+      - 'kind/refactor'
+      - 'kind/chore'
+      - 'kind/docs'
+  - title: 'Dependencies'
+    labels:
+      - 'kind/dependencies'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+version-resolver:
+  minor:
+    labels:
+      - 'kind/feature'
+  default: patch
+prerelease: false
+template: |
+  $CHANGES


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Added a release drafter workflow for better release management.

On `main` branch, we're getting https://github.com/BirthdayResearch/liquidity.dfi.dev/runs/7604818524?check_suite_focus=true

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
