### PR TITLE
feat(pool): dfi logo

### DIFF
--- a/src/components/CurrencyLogo/index.tsx
+++ b/src/components/CurrencyLogo/index.tsx
@@ -39,6 +39,8 @@ export default function CurrencyLogo({
   const srcs: string[] = useMemo(() => {
     if (currency === ETHER) return []
 
+    if (currency?.symbol === 'DFI') return ['https://s2.coinmarketcap.com/static/img/coins/64x64/5804.png']
+
     if (currency instanceof Token) {
       if (currency instanceof WrappedTokenInfo) {
         return [...uriLocations, getTokenLogoURL(currency.address)]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Uniswap retrieves the logo URI **very differently** depending on whether is it on the `Pool` page (uses `Currency`) or on the individual `AddLiquidity` page (uses `WrappedTokenInfo`).

By default tokens are passed as `WrappedTokenInfo`, and because Uniswap interface unwraps the `WrappedTokenInfo` inside the `Pool` page, we'll lose the `logoURI` variable, and Uniswap will retrieve it from Trust Wallet by way of `currency.address`. Please refer to `CurrencyLogo` component to see how logo URI retrieval works internally.

<img width="698" alt="image" src="https://user-images.githubusercontent.com/506667/182433559-dd668231-b3bc-45a7-9d52-b87d43dd5be5.png">


Unfortunately at this point Trust Wallet will not add DFI logo because we do not meet their requirements, we'll have to hardcode it this way. On code cleanliness, we can come back to this again...

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
