### PR TITLE
chore: swap symbol A and B display

### DIFF
--- a/src/components/PositionCard/index.tsx
+++ b/src/components/PositionCard/index.tsx
@@ -163,8 +163,8 @@ export function MinimalPositionCard({ pair, showUnwrapped = false, border }: Pos
 }
 
 export default function FullPositionCard({ pair, border, stakedBalance, claimable, proxyAddress }: PositionCardProps) {
-  const currency1 = unwrappedToken(pair.token0)
-  const currency0 = unwrappedToken(pair.token1)
+  const currency0 = unwrappedToken(pair.token0)
+  const currency1 = unwrappedToken(pair.token1)
 
   const [showMore, setShowMore] = useState(false)
 
@@ -186,8 +186,8 @@ export default function FullPositionCard({ pair, border, stakedBalance, claimabl
     // this condition is a short-circuit in the case where useTokenBalance updates sooner than useTotalSupply
     JSBI.greaterThanOrEqual(totalPoolTokens.raw, userPoolBalance.raw)
       ? [
-          pair.getLiquidityValue(pair.token1, totalPoolTokens, userPoolBalance, false),
-          pair.getLiquidityValue(pair.token0, totalPoolTokens, userPoolBalance, false)
+          pair.getLiquidityValue(pair.token0, totalPoolTokens, userPoolBalance, false),
+          pair.getLiquidityValue(pair.token1, totalPoolTokens, userPoolBalance, false)
         ]
       : [undefined, undefined]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

On mainnet, our underlying Uniswap pairs are created with DFI as `symbolA`. So we need to update this back to the original order. Else on Pool page it'll show up as `ETH/DFI`, `USDT/DFI` and `USDC/DFI`.

Swapping back will show DFI as symbolA:
<img width="752" alt="image" src="https://user-images.githubusercontent.com/506667/183394152-d1117606-af52-462d-ac9e-72d3cc55d081.png">


#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
