### PR TITLE
fix(pool): allow claim only when claimable > 0

### DIFF
--- a/src/components/PositionCard/index.tsx
+++ b/src/components/PositionCard/index.tsx
@@ -316,7 +316,13 @@ export default function FullPositionCard({ pair, border, stakedBalance, claimabl
                 >
                   Remove
                 </ButtonPrimary>
-                <ButtonPrimary padding="8px" borderRadius="8px" onClick={claimCallback} width="32%">
+                <ButtonPrimary
+                  padding="8px"
+                  borderRadius="8px"
+                  onClick={claimCallback}
+                  disabled={claimable && claimable.greaterThan('0') ? false : true}
+                  width="32%"
+                >
                   Claim
                 </ButtonPrimary>
               </RowBetween>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

In this PR, am making ui/ux improvements to `Pool` page -- we're only letting users `Claim` their DFI rewards only when available DFI rewards > 0. This is to prevent unnecessary contract interactions esp. when users can't claim anything.

<img width="664" alt="image" src="https://user-images.githubusercontent.com/506667/183410449-a1f6085e-65ec-4add-92c0-3110314e834e.png">


#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #60

#### Additional comments?:
