### PR TITLE
feat(pool): show all pools by default

### DIFF
--- a/src/components/PositionCard/index.tsx
+++ b/src/components/PositionCard/index.tsx
@@ -178,7 +178,6 @@ export default function FullPositionCard({ pair, border, stakedBalance, claimabl
       ? new Percent(userPoolBalance.raw, totalStake.raw)
       : undefined
 
-  // pair.token1 -> token0Deposited and pair.token0 -> token1Deposited is intended
   const [token0Deposited, token1Deposited] =
     !!pair &&
     !!totalPoolTokens &&
@@ -279,7 +278,7 @@ export default function FullPositionCard({ pair, border, stakedBalance, claimabl
                 Your pool share:
               </Text>
               <Text fontSize={16} fontWeight={500}>
-                {poolTokenPercentage
+                {poolTokenPercentage?.greaterThan('0')
                   ? (poolTokenPercentage.toFixed(2) === '0.00' ? '<0.01' : poolTokenPercentage.toFixed(2)) + '%'
                   : '-'}
               </Text>
@@ -296,35 +295,39 @@ export default function FullPositionCard({ pair, border, stakedBalance, claimabl
               </FixedHeightRow>
             )}
 
-            {userPoolBalance && JSBI.greaterThan(userPoolBalance.raw, BIG_INT_ZERO) && (
+            {userPoolBalance && (
               <RowBetween marginTop="10px">
                 <ButtonPrimary
                   padding="8px"
                   borderRadius="8px"
                   as={Link}
                   to={`/add/${currencyId(currency0)}/${currencyId(currency1)}`}
-                  width="32%"
+                  width={JSBI.greaterThan(userPoolBalance.raw, BIG_INT_ZERO) ? '32%' : '100%'}
                 >
                   Add
                 </ButtonPrimary>
-                <ButtonPrimary
-                  padding="8px"
-                  borderRadius="8px"
-                  as={Link}
-                  width="32%"
-                  to={`/remove/${currencyId(currency0)}/${currencyId(currency1)}`}
-                >
-                  Remove
-                </ButtonPrimary>
-                <ButtonPrimary
-                  padding="8px"
-                  borderRadius="8px"
-                  onClick={claimCallback}
-                  disabled={claimable && claimable.greaterThan('0') ? false : true}
-                  width="32%"
-                >
-                  Claim
-                </ButtonPrimary>
+                {JSBI.greaterThan(userPoolBalance.raw, BIG_INT_ZERO) && (
+                  <>
+                    <ButtonPrimary
+                      padding="8px"
+                      borderRadius="8px"
+                      as={Link}
+                      width="32%"
+                      to={`/remove/${currencyId(currency0)}/${currencyId(currency1)}`}
+                    >
+                      Remove
+                    </ButtonPrimary>
+                    <ButtonPrimary
+                      padding="8px"
+                      borderRadius="8px"
+                      onClick={claimCallback}
+                      disabled={claimable && claimable.greaterThan('0') ? false : true}
+                      width="32%"
+                    >
+                      Claim
+                    </ButtonPrimary>
+                  </>
+                )}
               </RowBetween>
             )}
           </AutoColumn>

--- a/src/pages/Pool/index.tsx
+++ b/src/pages/Pool/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react'
+import React, { useContext } from 'react'
 import styled, { ThemeContext } from 'styled-components'
 import { Link } from 'react-router-dom'
 import { SwapPoolTabs } from '../../components/NavigationTabs'
@@ -67,12 +67,8 @@ export default function Pool() {
 
   const proxies = useProxies()
   const [userProxyLiquidity, fetchingProxyLiquidity] = useGetProxyLiquidityOfUser(account ?? undefined, proxies)
-  const proxyWithBalance = useMemo(() => proxies.filter(p => userProxyLiquidity[p.address]?.greaterThan('0')), [
-    proxies,
-    userProxyLiquidity
-  ])
 
-  const proxyV2Pairs2 = usePairs2(proxyWithBalance.map(p => [p.tokenA, p.tokenB, p.address]))
+  const proxyV2Pairs2 = usePairs2(proxies.map(p => [p.tokenA, p.tokenB, p.address]))
   const proxyV2PairsWithLiquidity2 = proxyV2Pairs2
     .map(([, pair]) => pair)
     .filter((v2Pair): v2Pair is ProxyPair => Boolean(v2Pair))
@@ -82,7 +78,7 @@ export default function Pool() {
   const userProxyLiquidityIsLoading =
     fetchingProxyLiquidity ||
     fetchingClaimable ||
-    proxyV2Pairs2?.length < proxyWithBalance.length ||
+    proxyV2Pairs2?.length < proxies.length ||
     proxyV2Pairs2?.some(V2Pair => !V2Pair)
 
   return (
@@ -154,7 +150,7 @@ export default function Pool() {
                   <Dots>Loading</Dots>
                 </TYPE.body>
               </EmptyProposals>
-            ) : proxyWithBalance?.length > 0 ? (
+            ) : proxies?.length > 0 ? (
               <>
                 {proxyV2PairsWithLiquidity2.map(v2Pair => (
                   <FullPositionCard


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

In this PR,

- am showing all proxy pools by default
- if a user's wallet doesn't have any of the LP, it'll still show up but with zero values and a link to `Add`

<img width="538" alt="image" src="https://user-images.githubusercontent.com/506667/183418864-b27ef221-f67c-486b-948f-553c1188c2cc.png">

If a user doesn't have a wallet connected, they'll see this and it's working as intended. We'll show the pools in a separate PR.

<img width="538" alt="image" src="https://user-images.githubusercontent.com/506667/183419129-dfc1df67-2ba7-47c4-855c-7ff608352d1a.png">



#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #73

#### Additional comments?:
