### PR TITLE
fix(pool): displaying APR with 2dp

### DIFF
--- a/src/components/PositionCard/index.tsx
+++ b/src/components/PositionCard/index.tsx
@@ -299,7 +299,7 @@ export default function FullPositionCard({ pair, border, stakedBalance, claimabl
               {!currency0 || !currency1 ? <Dots>Loading</Dots> : `${currency0.symbol}/${currency1.symbol}`}
             </Text>
             <Text fontWeight={500} fontSize={14}>
-              <Badge>{aprValue ? Math.round(aprValue*100)/100 + '% APR' : ''}</Badge>
+              <Badge>{aprValue ? Math.round(aprValue * 100) / 100 + '% APR' : ''}</Badge>
             </Text>
           </AutoRow>
           <RowFixed gap="8px">
@@ -338,7 +338,7 @@ export default function FullPositionCard({ pair, border, stakedBalance, claimabl
                   APR:
                 </Text>
                 <Text fontSize={16} fontWeight={500}>
-                  {aprValue ? Math.round(aprValue*100)/100 + '%' : ''}
+                  {aprValue ? Math.round(aprValue * 100) / 100 + '%' : ''}
                 </Text>
               </FixedHeightRow>
               <FixedHeightRow>

--- a/src/components/PositionCard/index.tsx
+++ b/src/components/PositionCard/index.tsx
@@ -299,7 +299,7 @@ export default function FullPositionCard({ pair, border, stakedBalance, claimabl
               {!currency0 || !currency1 ? <Dots>Loading</Dots> : `${currency0.symbol}/${currency1.symbol}`}
             </Text>
             <Text fontWeight={500} fontSize={14}>
-              <Badge>{aprValue ? Math.round(aprValue) + '% APR' : ''}</Badge>
+              <Badge>{aprValue ? Math.round(aprValue*100)/100 + '% APR' : ''}</Badge>
             </Text>
           </AutoRow>
           <RowFixed gap="8px">
@@ -338,7 +338,7 @@ export default function FullPositionCard({ pair, border, stakedBalance, claimabl
                   APR:
                 </Text>
                 <Text fontSize={16} fontWeight={500}>
-                  {aprValue ? Math.round(aprValue) + '%' : ''}
+                  {aprValue ? Math.round(aprValue*100)/100 + '%' : ''}
                 </Text>
               </FixedHeightRow>
               <FixedHeightRow>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Display APR in 2 decimal places
#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
